### PR TITLE
test/Add new load test #294

### DIFF
--- a/loadtest/locustfile.py
+++ b/loadtest/locustfile.py
@@ -13,6 +13,8 @@ from locust import (
 
 HOST = "http://localhost:8000"
 VOTING = 1
+#VOTING_TYPE: "yesno" || "classic" || "comment" || "preference" || "choices"
+VOTING_TYPE = "preference" 
 
 
 class DefVisualizer(TaskSet):
@@ -40,7 +42,15 @@ class DefVoters(SequentialTaskSet):
     @task
     def getuser(self):
         self.usr= self.client.post("/authentication/getuser/", self.token).json()
-        print( str(self.user))
+        print( str(self.usr))
+
+    @task
+    def booth(self):
+        headers = {
+            'Authorization': 'Token ' + self.token.get('token'),
+            'content-type': 'text/html'
+        }
+        self.client.get("/booth/{0}/".format(VOTING), headers=headers)
 
     @task
     def voting(self):
@@ -48,19 +58,64 @@ class DefVoters(SequentialTaskSet):
             'Authorization': 'Token ' + self.token.get('token'),
             'content-type': 'application/json'
         }
-        self.client.post("/store/", json.dumps({
-            "token": self.token.get('token'),
-            "vote": {
-                "a": "12",
-                "b": "64"
-            },
-            "voter": self.usr.get('id'),
-            "voting": VOTING
-        }), headers=headers)
+        if VOTING_TYPE != "choices":
+            self.client.post("/store/", json.dumps({
+                "token": self.token.get('token'),
+                "vote": {
+                    "a": "12",
+                    "b": "64"
+                },
+                "voter": self.usr.get('id'),
+                "voting": VOTING,
+                "voting_type": VOTING_TYPE
+            }), headers=headers)
+        else:
+            self.client.post("/store/", json.dumps({
+                "token": self.token.get('token'),
+                "votes": [{
+                    "a": "12",
+                    "b": "64"
+                },
+                {
+                    "a": "24",
+                    "b": "38"
+                }],
+                "voter": self.usr.get('id'),
+                "voting": VOTING,
+                "voting_type": VOTING_TYPE
+            }), headers=headers)
 
 
     def on_quit(self):
         self.voter = None
+
+class DefBooth(TaskSet):
+    @task
+    def index(self):
+        self.client.get("/booth/{0}/".format(VOTING))
+
+class DefHome(SequentialTaskSet):
+    
+    def on_start(self):
+        with open('voters.json') as f:
+            self.voters = json.loads(f.read())
+        self.voter = choice(list(self.voters.items()))
+    
+    @task
+    def index(self):
+        self.client.get("/")
+
+    @task
+    def login_view(self):
+        self.client.get("/authentication/login-view/")
+
+    @task
+    def login(self):
+        username, pwd = self.voter
+        self.token = self.client.post("/authentication/login/", {
+            "username": username,
+            "password": pwd,
+        }).json()
 
 class Visualizer(HttpUser):
     host = HOST
@@ -73,3 +128,13 @@ class Voters(HttpUser):
     host = HOST
     tasks = [DefVoters]
     wait_time= between(3,5)
+
+class Booth(HttpUser):
+    host = HOST
+    tasks = [DefBooth]
+    wait_time = between(3,5)    
+
+class Home(HttpUser):
+    host = HOST
+    tasks = [DefHome]
+    wait_time = between(3,5)    


### PR DESCRIPTION
This PR resolves incidence #294 
Created two new locust load tests:
Home (which simulates users entering the homepage and then authenticating)
Booth (which simulates users entering a booth for voting)

I have also updated the Voters test, to match the current implementation of store.
In order to run the tests, you previously have to:
- Have decide running in the background
- Execute gen_census.py
- Create a voting, and start it
- Update the `VOTING` and `VOTING_TYPE` variables in the locust file to match those of the started voting
- Run `locust Voters` (also `Home` or `Booth`)
