### PR TITLE
Conf/docker deployment

### DIFF
--- a/decide/decide/settings.py
+++ b/decide/decide/settings.py
@@ -178,6 +178,15 @@ KEYBITS = 256
 ALLOWED_VERSIONS = ['v1', 'v2']
 DEFAULT_VERSION = 'v1'
 
+CELERY_BROKER_URL = os.environ.get("BROKER_URL", "redis://localhost:6379/0")
+CELERY_RESULT_BACKEND = os.environ.get("RESULT_BACKEND", "redis://localhost:6379/0")
+CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
+CELERY_ACCEPT_CONTENT = ['json']
+CELERY_TASK_SERIALIZER = 'json'
+CELERY_RESULT_SERIALIZER = 'json'
+CELERY_TIMEZONE = 'UTC'
+CELERY_TASK_DEFAULT_QUEUE = 'default'
+
 try:
     from local_settings import *
 except ImportError:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-from python:3.9-alpine
+from python:3.10-alpine
 
 RUN apk add --no-cache git postgresql-dev gcc libc-dev
 RUN apk add --no-cache gcc g++ make libffi-dev python3-dev build-base
@@ -10,7 +10,8 @@ RUN pip install ipython
 
 WORKDIR /app
 
-RUN git clone https://github.com/decide-update-4-1/decide-update-4.1.git .
+ARG BRANCH=main
+RUN git clone -b $BRANCH https://github.com/EGC-23-24/decide-part-lorca.git .
 RUN pip install -r requirements.txt
 
 WORKDIR /app/decide

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,18 +4,22 @@ services:
   db:
     restart: always
     container_name: decide_db
-    image: postgres:11.18-bullseye
+    image: postgres:14.9-alpine
     volumes:
       - db:/var/lib/postgresql/data
     networks:
       - decide
     environment:
-      - POSTGRES_PASSWORD=
+      - POSTGRES_PASSWORD=postgres
   web:
     restart: always
     container_name: decide_web
     image: decide_web:latest
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - BRANCH=main
     command: ash -c "python manage.py migrate && gunicorn -w 5 decide.wsgi --timeout=500 -b 0.0.0.0:5000"
     expose:
       - "5000"
@@ -25,6 +29,9 @@ services:
       - db
     networks:
       - decide
+    environment:
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/0
   nginx:
     restart: always
     container_name: decide_nginx
@@ -40,6 +47,29 @@ services:
       - web
     networks:
       - decide
+  redis:
+    restart: always
+    container_name: decide_redis
+    image: redis:alpine
+    expose:
+      - 6379
+    networks:
+      - decide
+  worker:
+    restart: always
+    container_name: decide_celery
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: ash -c "python -m celery -A decide worker --uid=nobody"
+    depends_on:
+      - redis
+    networks:
+      - decide
+    environment:
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+
 
 volumes:
   static:

--- a/docker/docker-settings.py
+++ b/docker/docker-settings.py
@@ -5,7 +5,7 @@ DATABASES = {
         'ENGINE': 'django.db.backends.postgresql',
         'NAME': 'postgres',
         'USER': 'postgres',
-        'PASSWORD':'',
+        'PASSWORD':'postgres',
         'HOST': 'db',
         'PORT': 5432,
     }
@@ -15,7 +15,7 @@ STATIC_ROOT = '/app/static/'
 MEDIA_ROOT = '/app/static/media/'
 ALLOWED_HOSTS = ['*']
 
-CSRF_TRUSTED_ORIGINS = ['http://10.5.0.1:8000']
+CSRF_TRUSTED_ORIGINS = ['http://10.5.0.1:8000', 'http://localhost:8000']
 
 # Modules in use, commented modules that you won't use
 MODULES = [


### PR DESCRIPTION
This Docker Compose configuration launches 5 containers: one for the database server, another for Django, one for the Nginx web server, another for the Celery service, and one for the Redis message broker:

- `decide_db`
- `decide_web`
- `decide_nginx`
- `decide_celery`
- `decide_redis`

Additionally, two volumes are created, one for the project's static files and media, and another for the PostgreSQL database. This ensures that containers can be distributed without fear of data loss:

- `decide_static`
- `decide_db`

The `docker-settings.py` file can be edited to modify the Django project settings before creating the container images:

### Container Creation and Launch Process

#### Creating Images and Launching Containers

```bash
cd docker
docker-compose up
```

> Note: When launching the containers, an argument can be passed to start the project from the state of a specific branch. By default, the branch launched in Docker is the 'main' branch of the repository.
> 
> To launch a specific branch, for example, `epic/54-predefined-end-date`, execute the following command:
> 
> `docker-compose build --build-arg BRANCH=epic/54-predefined-end-date`
> 
> Once the above command is executed, we can launch the containers with the command
> 
> `docker-compose up`

#### Stopping containers

```bash
docker-compose down
```

#### Creating an Admin user

```bash
docker exec -it decide_web ./manage.py createsuperuser
```

#### Launching the Django console

```bash
docker exec -it decide_web ./manage.py shell
```

#### Running tests

```bash
docker exec -it decide_web ./manage.py test
```

#### Launching an SQL console

```bash
docker exec -ti decide_db ash -c "su - postgres -c 'psql postgres'"
```

#### Viewing Celery container logs

```bash
docker logs -f decide_celery
```

--- 

Note: Depending on your Docker configuration, you may need to execute some of the above commands with superuser privileges.