### PR TITLE
feat: add all docs to GitHub Pages #329

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -24,6 +24,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
+    - name: Add All Documentation
+      run: |
+        cp -r doc/* decide/sphinx_docs/source/doc/
+
     - name: Generate Documentation
       run: |
         cd decide

--- a/decide/sphinx_docs/source/conf.py
+++ b/decide/sphinx_docs/source/conf.py
@@ -25,7 +25,8 @@ release = '0.0.0'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
-    'sphinx.ext.napoleon'
+    'sphinx.ext.napoleon',
+    'myst_parser',
 ]
 
 templates_path = ['_templates']

--- a/decide/sphinx_docs/source/doc/index.rst
+++ b/decide/sphinx_docs/source/doc/index.rst
@@ -1,0 +1,12 @@
+Decide doc files
+================
+
+This section gathers all the documents that have been prepared in relation to the project.
+
+The documents can be accessed through the following table of contents.
+
+.. toctree::
+    :titlesonly:
+    :glob:
+
+    *.md

--- a/decide/sphinx_docs/source/index.rst
+++ b/decide/sphinx_docs/source/index.rst
@@ -25,5 +25,6 @@ This Django project will be divided into apps (subsystems and base project), whe
    :titlesonly:
 
    modules/index
+   doc/index
    memes
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,4 @@ Pygments==2.17.2
 accessible-pygments==0.0.4
 typing_extensions==4.8.0
 soupsieve==2.5
+myst-parser==2.0.0


### PR DESCRIPTION
I have added all the project documents to the GitHub Pages.
You can view the documentation at: [Documentation-decide-part-lorca](https://egc-23-24.github.io/decide-part-lorca/modules/index.html)
This PR resolve the incident #329